### PR TITLE
Run `documentation-links` step on PR events only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
   # https://github.com/readthedocs/actions/tree/main/preview
   documentation-links:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: readthedocs/actions/preview@v1
         with:


### PR DESCRIPTION


<!-- readthedocs-preview ridgeplot start -->
----
📚 Documentation preview 📚: https://ridgeplot--175.org.readthedocs.build/en/175/

<!-- readthedocs-preview ridgeplot end -->