### PR TITLE
Enforce strict mypy mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Unreleased changes
 
 - Migrate from `setup.cfg` from `pyproject.toml` ([#176](https://github.com/tpvasconcelos/ridgeplot/pull/176))
 - Use `importlib.resources` to load data assets from within the package - to be PEP-302 compliant ([#176](https://github.com/tpvasconcelos/ridgeplot/pull/176))
+- Enforce "strict" mypy mode (mostly improved type annotations for generic types) ([#177](https://github.com/tpvasconcelos/ridgeplot/pull/177))
 
 ---
 

--- a/src/ridgeplot/_colors.py
+++ b/src/ridgeplot/_colors.py
@@ -60,7 +60,7 @@ def validate_colorscale(colorscale: ColorScale) -> None:
     validate_colors(colors=colors)
 
 
-def _any_to_rgb(color: Union[str, tuple]) -> str:
+def _any_to_rgb(color: Union[str, Tuple[float, float, float]]) -> str:
     """Convert any color to an rgb string.
 
     Parameters

--- a/src/ridgeplot/_colors.py
+++ b/src/ridgeplot/_colors.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, Tuple, cast
+from typing import TYPE_CHECKING, Iterable, Tuple, Union, cast
 
 from _plotly_utils.colors import validate_colors, validate_scale_values
 from plotly.colors import find_intermediate_color, hex_to_rgb, label_rgb
@@ -11,7 +11,7 @@ from plotly.colors import find_intermediate_color, hex_to_rgb, label_rgb
 from ridgeplot._utils import LazyMapping, normalise_min_max
 
 if TYPE_CHECKING:
-    from typing import Dict, List, Union
+    from typing import Dict, List
 
 
 _PATH_TO_COLORS_JSON = Path(__file__).parent.joinpath("colors.json")
@@ -39,11 +39,18 @@ For instance, the Viridis colorscale would be defined as
  (1.0, 'rgb(253, 231, 37)'))
 """
 
+_Color = Union[
+    # rgb string
+    str,
+    # rgb tuple
+    Tuple[float, float, float],
+]
+
 
 def _colormap_loader() -> Dict[str, ColorScale]:
-    colors: dict = json.loads(_PATH_TO_COLORS_JSON.read_text())
+    colors: dict[str, ColorScale] = json.loads(_PATH_TO_COLORS_JSON.read_text())
     for name, colorscale in colors.items():
-        colors[name] = tuple(tuple(entry) for entry in colorscale)
+        colors[name] = tuple((s, c) for s, c in colorscale)
     return colors
 
 
@@ -60,7 +67,7 @@ def validate_colorscale(colorscale: ColorScale) -> None:
     validate_colors(colors=colors)
 
 
-def _any_to_rgb(color: Union[str, Tuple[float, float, float]]) -> str:
+def _any_to_rgb(color: _Color) -> str:
     """Convert any color to an rgb string.
 
     Parameters
@@ -188,6 +195,6 @@ def get_color(colorscale: ColorScale, midpoint: float) -> str:
     )
 
 
-def apply_alpha(color: Union[tuple, str], alpha: float) -> str:
+def apply_alpha(color: _Color, alpha: float) -> str:
     color = _any_to_rgb(color)
     return f"rgba({color[4:-1]}, {alpha})"

--- a/src/ridgeplot/_kde.py
+++ b/src/ridgeplot/_kde.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Callable, Union
+from typing import TYPE_CHECKING, Any, Callable, Union
 
 import numpy as np
 import statsmodels.api as sm
@@ -72,7 +72,7 @@ def estimate_density_trace(
 
 
 def _validate_densities(
-    x: npt.NDArray[np.floating], y: npt.NDArray[np.floating], kernel: str
+    x: npt.NDArray[np.floating[Any]], y: npt.NDArray[np.floating[Any]], kernel: str
 ) -> None:
     # I haven't investigated the root of this issue yet
     # but statsmodels' KDEUnivariate implementation

--- a/src/ridgeplot/_types.py
+++ b/src/ridgeplot/_types.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Tuple, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, Collection, Tuple, TypeVar, Union, overload
 
 import numpy as np
 
 if TYPE_CHECKING:
-    from typing import Any, Literal
+    from typing import Literal
 
 
 # Snippet used to generate and store the image artefacts:
@@ -67,10 +67,10 @@ Example:
 # ---  Numeric types
 # ========================================================
 
-Float = Union[float, np.floating]
+Float = Union[float, "np.floating[Any]"]
 """A :data:`~typing.TypeAlias` for float types."""
 
-Int = Union[int, np.integer]
+Int = Union[int, "np.integer[Any]"]
 """A :data:`~typing.TypeAlias` for a int types."""
 
 Numeric = Union[Int, Float]
@@ -108,7 +108,7 @@ Example:
 >>> xy_coord = (1, 2)
 """
 
-DensityTrace = CollectionL1[XYCoordinate]
+DensityTrace = CollectionL1[XYCoordinate[Any]]
 r"""A 2D line/trace represented as a collection of :math:`(x, y)` coordinates
 (i.e. :data:`XYCoordinate`\s).
 

--- a/src/ridgeplot/_utils.py
+++ b/src/ridgeplot/_utils.py
@@ -32,7 +32,7 @@ def normalise_min_max(val: Numeric, min_: Numeric, max_: Numeric) -> float:
     return float((val - min_) / (max_ - min_))
 
 
-def get_collection_array_shape(arr: Collection) -> Tuple[Union[int, Set[int]], ...]:
+def get_collection_array_shape(arr: Collection[Any]) -> Tuple[Union[int, Set[int]], ...]:
     """Return the shape of a :class:`~typing.Collection` array.
 
     Parameters

--- a/tests/unit/test_colors.py
+++ b/tests/unit/test_colors.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Type, Union
+from typing import Any, Optional, Tuple, Type, Union
 
 import pytest
 from _plotly_utils.exceptions import PlotlyError
@@ -115,7 +115,7 @@ def test_validate_colorscale_fails_for_invalid_colorscale(
         ((4, 5, 6), "rgb(4, 5, 6)"),  # valid tuple
     ],
 )
-def test_any_to_rgb(color: Union[str, tuple], expected: str) -> None:
+def test_any_to_rgb(color: Union[str, Tuple[float, float, float]], expected: str) -> None:
     assert _any_to_rgb(color=color) == expected
 
 
@@ -223,5 +223,7 @@ def test_get_color_fails_for_midpoint_out_of_bounds(midpoint: float) -> None:
         ((4, 5, 6), 1.0, "rgba(4, 5, 6, 1.0)"),
     ],
 )
-def test_apply_alpha(color: Union[tuple, str], alpha: float, expected: str) -> None:
+def test_apply_alpha(
+    color: Union[Tuple[float, float, float], str], alpha: float, expected: str
+) -> None:
     assert apply_alpha(color=color, alpha=alpha) == expected

--- a/tests/unit/test_colors.py
+++ b/tests/unit/test_colors.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Tuple, Type, Union
+from typing import Any, Optional, Type
 
 import pytest
 from _plotly_utils.exceptions import PlotlyError
@@ -9,6 +9,7 @@ from ridgeplot._colors import (
     _COLORSCALE_MAPPING,
     ColorScale,
     _any_to_rgb,
+    _Color,
     _colormap_loader,
     apply_alpha,
     get_color,
@@ -115,7 +116,7 @@ def test_validate_colorscale_fails_for_invalid_colorscale(
         ((4, 5, 6), "rgb(4, 5, 6)"),  # valid tuple
     ],
 )
-def test_any_to_rgb(color: Union[str, Tuple[float, float, float]], expected: str) -> None:
+def test_any_to_rgb(color: _Color, expected: str) -> None:
     assert _any_to_rgb(color=color) == expected
 
 
@@ -223,7 +224,5 @@ def test_get_color_fails_for_midpoint_out_of_bounds(midpoint: float) -> None:
         ((4, 5, 6), 1.0, "rgba(4, 5, 6, 1.0)"),
     ],
 )
-def test_apply_alpha(
-    color: Union[Tuple[float, float, float], str], alpha: float, expected: str
-) -> None:
+def test_apply_alpha(color: _Color, alpha: float, expected: str) -> None:
     assert apply_alpha(color=color, alpha=alpha) == expected

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Mapping
+from typing import Any, Mapping
 from unittest import mock
 
 import pytest
@@ -53,7 +53,7 @@ class TestLazyMapping:
     """Tests for the :func:`ridgeplot._utils.LazyMapping` class"""
 
     @pytest.mark.parametrize("target_mapping", [{}, {"a": 1, "b": 2, "c": 3}])
-    def test_mapping(self, target_mapping: Mapping) -> None:
+    def test_mapping(self, target_mapping: Mapping[Any, Any]) -> None:
         """Test the part of the implantation of the ``_mapping`` property.
 
         This test should assert that `._inner_mapping` is not defined before
@@ -72,7 +72,7 @@ class TestLazyMapping:
         assert lm._inner_mapping is m
 
     @pytest.mark.parametrize("target_mapping", [{}, {"a": 1, "b": 2, "c": 3}])
-    def test_loader_called_only_once(self, target_mapping: Mapping) -> None:
+    def test_loader_called_only_once(self, target_mapping: Mapping[Any, Any]) -> None:
         """Check that ``LazyMapping`` only calls ``._loader()`` once."""
         lm = LazyMapping(loader=lambda: target_mapping)
         with mock.patch.object(lm, "_loader") as loader:
@@ -89,7 +89,9 @@ class TestLazyMapping:
             assert loader.call_count == 2
 
     @pytest.mark.parametrize("target_mapping", [{}, {"a": 1, "b": 2, "c": 3}])
-    def test_mapping_mirrors_mapping_returned_by_loader(self, target_mapping: Mapping) -> None:
+    def test_mapping_mirrors_mapping_returned_by_loader(
+        self, target_mapping: Mapping[Any, Any]
+    ) -> None:
         """Test that LazyMapping behaves just like the mapping returned by the
         ``loader`` callable argument.
 

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ deps =
     types-tqdm
     pandas-stubs
 commands =
-    mypy --config-file=mypy.ini --cache-dir=/dev/null --no-incremental {posargs:}
+    mypy --config-file=mypy.ini --cache-dir=/dev/null --no-incremental --strict {posargs:}
 
 [testenv:docs-{live,static}]
 description = generate Sphinx (live/static) HTML documentation


### PR DESCRIPTION
Enforce strict mypy mode everywhere. Mostly improved type annotations for generic types

<!-- readthedocs-preview ridgeplot start -->
----
📚 Documentation preview 📚: https://ridgeplot--177.org.readthedocs.build/en/177/

<!-- readthedocs-preview ridgeplot end -->