### PR TITLE
Publish to PyPi as a Trusted Publisher

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,7 +1,0 @@
-# GitHub workflows
-
-| Workflow                 | Description                                                                                                                           |
-| ------------------------ |---------------------------------------------------------------------------------------------------------------------------------------|
-| check-release-notes.yaml | Checks whether the user remembered to update the changelog.                                                                           |
-| ci.yaml                  | Run all CI checks on all pushes to the main branch or pull-request updates.                                                           |
-| release.yaml             | Publishes a new GitHub release whenever a new git tag is pushed, followed by building and publishing the new package version to PyPI. |

--- a/.github/workflows/check-release-notes.yaml
+++ b/.github/workflows/check-release-notes.yaml
@@ -1,3 +1,6 @@
+# This workflow checks whether the user remembered to update
+# the changelog with a relevant entry for the PR.
+# This check is skipped if the PR has the "skip news" label.
 name: Check Release Notes
 
 on:
@@ -5,7 +8,7 @@ on:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
 
 jobs:
-  build:
+  check:
     name: Check for entry in Changelog
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-release-notes.yaml
+++ b/.github/workflows/check-release-notes.yaml
@@ -11,6 +11,7 @@ jobs:
   check:
     name: Check for entry in Changelog
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@v4
       - name: Grep Changelog for PR number

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
   documentation-links:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    timeout-minutes: 1
     steps:
       - uses: readthedocs/actions/preview@v1
         with:
@@ -31,6 +32,7 @@ jobs:
   static-checks:
     name: Static checks
     runs-on: ubuntu-latest
+    timeout-minutes: 6
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python
@@ -70,6 +72,7 @@ jobs:
           # - windows-latest
       fail-fast: true
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,11 @@
-name: CI
+# Run all CI checks on all pushes to the main branch or pull-request updates.
+# This includes running static checks such as linting and type checking,
+# as well as running the test suite on all supported Python versions.
+# Coverage reports will be uploaded to Codecov and Codacy.
+#
+# The documentation will also be built, and a link to the docs will be
+# added to the PR description.
+name: CI checks
 
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,15 @@
+# This workflow builds source (sdist) and binary (wheel) distributions
+# for the Python package on every push event, followed by publishing
+# them to TestPyPi. This should be a good indicator that the build
+# and publishing process is always working correctly (as opposed
+# to only finding out when we actually want to publish a new
+# release).
+#
+# When new tags are pushed - in addition to the steps above -
+# we also publish the build distributions to the "real" PyPi
+# repository, and publish a new GitHub Release containing
+# the latest section extracted from the release notes
+# and the Sigstore-certified built distributions.
 name: Release workflow 🚀
 
 on: push
@@ -21,7 +33,7 @@ jobs:
           path: dist/
 
   publish-to-testpypi:
-    name: Publish Python distribution to TestPyPI
+    name: Publish distribution to TestPyPI
     needs:
       - build
     runs-on: ubuntu-latest
@@ -42,7 +54,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
   publish-to-pypi:
-    name: Publish Python distribution to PyPI
+    name: Publish distribution to PyPI
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,7 @@ jobs:
           requirements: tox
       - name: Build source (sdist) and binary (wheel) distributions
         run: tox -e build-dists
-      - name: Upload the distribution artifacts
-        uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3
         with:
           name: python-package-distributions
           path: dist/
@@ -43,15 +42,16 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v3
         with:
           name: python-package-distributions
           path: dist/
-      - name: Publish distribution to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          verbose: true
+          print-hash: true
 
   publish-to-pypi:
     name: Publish distribution to PyPI
@@ -66,13 +66,14 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v3
         with:
           name: python-package-distributions
           path: dist/
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          print-hash: true
 
   github-release:
     name: Publish a GitHub Release
@@ -95,8 +96,7 @@ jobs:
 
       # Sign the package distributions with Sigstore
       # https://github.com/marketplace/actions/gh-action-sigstore-python
-      - name: Download all the dists
-        uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v3
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
   build:
     name: Build distributions
     runs-on: ubuntu-latest
+    timeout-minutes: 6
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python
@@ -36,6 +37,7 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     environment:
       name: testpypi
       url: https://test.pypi.org/p/ridgeplot
@@ -60,6 +62,7 @@ jobs:
       - build
       - publish-to-testpypi
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     environment:
       name: pypi
       url: https://pypi.org/p/ridgeplot
@@ -80,6 +83,7 @@ jobs:
     needs:
       - publish-to-pypi
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
       id-token: write  # IMPORTANT: mandatory for sigstore

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,78 @@
-name: Release workflow
+name: Release workflow 🚀
 
-on:
-  push:
-    tags:
-      - "*.*.*"
+on: push
 
 jobs:
-  release:
+  build:
+    name: Build distributions
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: "3.8"
+          requirements: tox
+      - name: Build source (sdist) and binary (wheel) distributions
+        run: tox -e build-dists
+      - name: Upload the distribution artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-testpypi:
+    name: Publish Python distribution to TestPyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/ridgeplot
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build
+      - publish-to-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ridgeplot
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Publish a GitHub Release
+    needs:
+      - publish-to-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+    steps:
+
+      # Generate the release notes
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python
         with:
@@ -16,25 +80,25 @@ jobs:
           requirements: tox
       - name: Generate release notes
         run: tox -e release-notes
+
+      # Sign the package distributions with Sigstore
+      # https://github.com/marketplace/actions/gh-action-sigstore-python
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v1.2.3
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           body_path: LATEST_RELEASE_NOTES.md
-
-  build-and-publish-to-pypi:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-python
-        with:
-          python-version: "3.8"
-          requirements: tox
-      - name: Build and publish a release to TestPyPI
-        env:
-          TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN_TEST }}"
-        run: tox -e publish-pypi-test
-      - name: Build and publish a release PyPI
-        env:
-          TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"
-        run: tox -e publish-pypi-prod
+          # `dist/` contains the built distributions, and the
+          # Sigstore-produced signatures and certificates.
+          files: dist/**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.8
+  python: python3.8
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -29,6 +29,18 @@ repos:
         files: ^.*\.ipynb$
       - id: trailing-whitespace
         exclude: .bumpversion.cfg
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema.git
+    rev: 0.28.2
+    hooks:
+      - id: check-github-actions
+      - id: check-github-workflows
+      - id: check-jsonschema
+        name: "Check GitHub Workflows set timeout-minutes"
+        files: ^\.github/workflows/[^/]+$
+        types: [ yaml ]
+        args: [ "--builtin-schema", "github-workflows-require-timeout" ]
+      - id: check-readthedocs
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -5,7 +5,12 @@ This document outlines the list of changes to ridgeplot between each release. Fo
 Unreleased changes
 ------------------
 
+- ...
+
+### CI/CD
+
 - Move all CI/CD utilities to the `cicd_utils/` directory ({gh-issue}`186`)
+- Publish to PyPi as a Trusted Publisher ({gh-issue}`187`)
 
 ---
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -11,6 +11,7 @@ Unreleased changes
 
 - Move all CI/CD utilities to the `cicd_utils/` directory ({gh-issue}`186`)
 - Publish to PyPi as a Trusted Publisher ({gh-issue}`187`)
+- Add `check-jsonschema` pre-commit hooks and define `timeout-minutes` for all GitHub workflows ({gh-issue}`187`)
 
 ---
 

--- a/tox.ini
+++ b/tox.ini
@@ -90,18 +90,13 @@ deps =
     mdformat
 commands = python cicd_utils/scripts/extract_latest_release_notes.py
 
-[testenv:publish-pypi-{test,prod}]
-description = build and upload the source and wheel package to (test/prod) PyPI
+[testenv:build-dists]
+description = build source (sdist) and binary (wheel) distributions
 deps =
     build
     twine
 allowlist_externals = rm
-passenv =
-    {[testenv]passenv}
-    TWINE_PASSWORD
 commands =
     rm -rf dist/
     python -m build
     twine check --strict dist/*
-    test: twine upload --verbose --repository testpypi dist/*
-    prod: twine upload --verbose dist/*


### PR DESCRIPTION
References:
- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
- https://docs.pypi.org/trusted-publishers/

<!-- readthedocs-preview ridgeplot start -->
----
📚 Documentation preview 📚: https://ridgeplot--187.org.readthedocs.build/en/187/

<!-- readthedocs-preview ridgeplot end -->