### PR TITLE
Refactor `readthedocs-preview.yml` into own workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 # Run all CI checks on pushes to the main branch or pull-request updates.
 #
-# This includes: running static checks such as linting and type checking,
-# running the test suite on all supported Python versions, and uploading
-# coverage reports to Codecov and Codacy. Additionally, the Sphinx docs
-# are built, and a link to the docs will be added to the PR description
-#
+# This includes: static checks such as linting and type checking,
+# running the test suites on all supported Python versions,
+# and uploading coverage reports to Codecov and Codacy.
 name: CI checks
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,21 +16,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  pull-requests: write
-
 jobs:
-  # Build the docs and update the PR description w/ a link to readthedocs
-  # https://github.com/readthedocs/actions/tree/main/preview
-  documentation-links:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    timeout-minutes: 1
-    steps:
-      - uses: readthedocs/actions/preview@v1
-        with:
-          project-slug: "ridgeplot"
-
   # Run static checks only for Ubuntu and Python 3.9
   static-checks:
     name: Static checks

--- a/.github/workflows/readthedocs-preview.yml
+++ b/.github/workflows/readthedocs-preview.yml
@@ -1,0 +1,29 @@
+# Build the docs and update the PR description w/ a link to readthedocs
+# https://github.com/readthedocs/actions/tree/main/preview
+name: readthedocs (PR preview)
+
+on:
+  pull_request_target:
+    types: [ opened, synchronize ]
+    paths:
+      - '.github/workflows/readthedocs-preview.yml'
+      - 'cicd_utils/**'
+      - 'docs/**'
+      - 'src/**'
+      - '.readthedocs.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "ridgeplot"

--- a/.github/workflows/readthedocs-preview.yml
+++ b/.github/workflows/readthedocs-preview.yml
@@ -1,4 +1,5 @@
-# Build the docs and update the PR description w/ a link to readthedocs
+# Build the Sphinx docs and update the PR description
+# w/ a link to the rendered version on Read the Docs
 # https://github.com/readthedocs/actions/tree/main/preview
 name: readthedocs (PR preview)
 


### PR DESCRIPTION
Ran into permission issues in https://github.com/tpvasconcelos/ridgeplot/pull/262 due to the use of the `pull_request` event instead of `pull_request_target`