### PR TITLE
Consolidate bot PRs #379-#383 and fix pytest incompatibility blocking their CI

### DIFF
--- a/.github/workflows/check-release-notes.yml
+++ b/.github/workflows/check-release-notes.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Default MISSING_CHANGELOG_ENTRY to 1
         run: echo 'MISSING_CHANGELOG_ENTRY=1' >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 6
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-python
         with:
           python-version: "3.10"
@@ -68,7 +68,7 @@ jobs:
       DIFF_AGAINST: HEAD
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # TODO: This can be very expensive for large repos. Is there a better way to do this?
           # Fetch all history and tags for setuptools_scm to work

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       # Upload coverage reports to Codecov
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         env:
           OS: "${{ matrix.os }}"
           PYTHON: "${{ matrix.python-version }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
       # actions: read
       # contents: read
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - uses: github/codeql-action/init@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.3.0
+        uses: sigstore/gh-action-sigstore-python@v3.4.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
             ./dist/*.whl
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: LATEST_RELEASE_NOTES.md
           # `dist/` contains the built distributions, and the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 6
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # TODO: This can be very expensive for large repos. Is there a better way to do this?
           # Fetch all history and tags for setuptools_scm to work
@@ -105,7 +105,7 @@ jobs:
     steps:
 
       # Generate the release notes
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # TODO: This can be very expensive for large repos. Is there a better way to do this?
           # Fetch all history and tags for setuptools_scm to work

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         exclude: ^\.bumpversion\.cfg$
 
   - repo: https://github.com/python-jsonschema/check-jsonschema.git
-    rev: 0.37.2
+    rev: 0.37.4
     hooks:
       - id: check-github-actions
       - id: check-github-workflows
@@ -65,7 +65,7 @@ repos:
       - id: nbstripout
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         args: [ "-L", "probly", "-L", "mis" ]
@@ -104,7 +104,7 @@ repos:
         additional_dependencies: [setuptools-scm]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.13
+    rev: v0.15.22
     hooks:
       - id: ruff-format
       - id: ruff

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -13,6 +13,12 @@ Unreleased changes
 - Bump codecov/codecov-action from 5 to 6 ({gh-pr}`371`)
 - Bump actions/github-script from 8 to 9 ({gh-pr}`373`)
 - pre-commit autoupdate ({gh-pr}`374`)
+- Bump softprops/action-gh-release from 2 to 3 ({gh-pr}`380`)
+- Bump codecov/codecov-action from 6 to 7 ({gh-pr}`381`)
+- Bump sigstore/gh-action-sigstore-python from 3.3.0 to 3.4.0 ({gh-pr}`382`)
+- Bump actions/checkout from 6 to 7 ({gh-pr}`383`)
+- pre-commit autoupdate ({gh-pr}`379`)
+- Fix the test suite's compatibility with the latest pytest release ({gh-pr}`384`)
 
 ---
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -44,7 +44,7 @@ class TestGetXYExtrema:
 
     @pytest.mark.parametrize(
         ("densities_type", "rows_type"),
-        product((id_func, tuple, list), (id_func, tuple, list, np.asarray)),
+        list(product((id_func, tuple, list), (id_func, tuple, list, np.asarray))),
     )
     def test_expected_output(
         self,


### PR DESCRIPTION
Re-applies the changes from 5 open bot PRs into a single branch (following the precedent set by #378), together with the test-suite fix that was causing their CI failures.

## Why were these PRs failing CI?

All five bot PRs were failing the *Software tests* jobs for a reason unrelated to their changes: the latest pytest release deprecated passing a lazy iterator to `pytest.mark.parametrize`, and `tests/unit/test_utils.py::TestGetXYExtrema` passed an `itertools.product` object directly. Since the test config turns warnings into errors, collection failed everywhere (and the same deprecation also trips pyright in *Static checks*, seen on #383). The first commit here wraps it in `list(...)`.

## Consolidated changes

- **pre-commit autoupdate** ({gh-pr}`379`): check-jsonschema 0.37.2 → 0.37.4, codespell v2.4.2 → v2.4.3, ruff v0.15.13 → v0.15.22
- **softprops/action-gh-release** 2 → 3 (#380): Node 20 → 24 runtime only, no functional changes
- **codecov/codecov-action** 6 → 7 (#381): PGP key source change; all inputs used in `ci.yml` still supported
- **sigstore/gh-action-sigstore-python** 3.3.0 → 3.4.0 (#382): dependency updates only
- **actions/checkout** 6 → 7 (#383): new fork-PR guardrail only affects `pull_request_target`/`workflow_run` workflows that check out code — none here do

Changelog updated under `Unreleased changes > CI/CD`.

Closes #379
Closes #380
Closes #381
Closes #382
Closes #383

<!-- readthedocs-preview ridgeplot start -->
----
📚 Documentation preview 📚: https://ridgeplot--384.org.readthedocs.build/en/384/

<!-- readthedocs-preview ridgeplot end -->