### PR TITLE
Use astral-sh/setup-uv in the setup-python composite action

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -6,12 +6,6 @@ inputs:
   python-version:
     description: "Python version (e.g. '3.7', '3.8.13', '3.11.0-alpha.1', '3.x')."
     required: true
-  install-seed-packages:
-    description: >
-      Set to 'true' to install and/or upgrade seed packages (pip, setuptools, and wheel)
-      before installing other packages.
-    required: false
-    default: "false"
   requirements:
     description: "Optional list of arguments passed to `uv pip install` (e.g. 'numpy==1.19.5', '-r requirements.txt')."
     required: false
@@ -23,37 +17,17 @@ runs:
       with:
         python-version: "${{ inputs.python-version }}"
 
+    # Install uv and enable its built-in cache. The cache key takes the
+    # platform, the uv version, and a hash of the files below into account.
+    # See https://docs.astral.sh/uv/guides/integration/github/ for details.
     - name: Install uv
-      shell: bash
-      run: pip install --upgrade uv
-
-    # >>>>>>>> Caching uv packages >>>>>>>>
-
-    - name: Get uv cache dir
-      id: uv-cache
-      shell: bash
-      run: echo "dir=$(uv cache dir)" >> $GITHUB_OUTPUT
-
-    - name: Get the current date in format YYYYWW (year and week-of-year)
-      id: get-date
-      shell: bash
-      run: echo "date=$(/bin/date -u "+%Y%U")" >> $GITHUB_OUTPUT
-
-    - name: uv cache
-      uses: actions/cache@v4
+      uses: astral-sh/setup-uv@v9
       with:
-        path: ${{ steps.uv-cache.outputs.dir }}
-        # The cache's TTL is 7 days (one week)
-        key: uv-${{ runner.os }}-${{ inputs.python-version }}-${{ steps.get-date.outputs.date }}
-        # Fall back to the previous week's cache
-        restore-keys: uv-${{ runner.os }}-${{ inputs.python-version }}-
-
-    # <<<<<<<< Caching uv packages <<<<<<<<
-
-    - name: Install and/or upgrade seed packages
-      if: ${{ inputs.install-seed-packages == 'true' }}
-      shell: bash
-      run: uv pip install --verbose --system --upgrade pip setuptools wheel
+        enable-cache: true
+        cache-suffix: "py${{ inputs.python-version }}"
+        cache-dependency-glob: |
+          pyproject.toml
+          requirements/*.txt
 
     - name: Install requirements
       if: ${{ inputs.requirements != '' }}

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -20,8 +20,10 @@ runs:
     # Install uv and enable its built-in cache. The cache key takes the
     # platform, the uv version, and a hash of the files below into account.
     # See https://docs.astral.sh/uv/guides/integration/github/ for details.
+    # NOTE: setup-uv publishes immutable releases only (no
+    #       floating major tags), so we pin the full version
     - name: Install uv
-      uses: astral-sh/setup-uv@v9
+      uses: astral-sh/setup-uv@v9.0.0
       with:
         enable-cache: true
         cache-suffix: "py${{ inputs.python-version }}"

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -13,6 +13,7 @@ Unreleased changes
 - Bump codecov/codecov-action from 5 to 6 ({gh-pr}`371`)
 - Bump actions/github-script from 8 to 9 ({gh-pr}`373`)
 - pre-commit autoupdate ({gh-pr}`374`)
+- Use the official `astral-sh/setup-uv` action to install and cache `uv` in CI ({gh-pr}`386`)
 
 ---
 


### PR DESCRIPTION
## Description

Adopt the official [`astral-sh/setup-uv`](https://github.com/astral-sh/setup-uv) action in our `setup-python` composite action, as part of the broader `uv` adoption tracked in #219 (GitHub Actions integration item).

Changes:

- Install `uv` via `astral-sh/setup-uv@v9` instead of `pip install --upgrade uv` (faster: downloads a prebuilt binary and skips pip entirely).
- Replace the hand-rolled cache steps (cache dir lookup + weekly date-based cache key) with the action's built-in caching. The cache key now includes the platform, the uv version, and a hash of `pyproject.toml` + `requirements/*.txt`, plus a per-Python-version suffix (mirroring the previous behavior of one cache per Python version). Since uv releases frequently, the uv version in the key also gives us organic cache rotation, replacing the previous weekly TTL.
- Drop the unused `install-seed-packages` input (no callers use it).

The `python-version` and `requirements` inputs and the `uv pip install --system` behavior are unchanged, so no workflow changes are needed.

## Related issues

Related to #219.

## PR check list

- [x] Read the [contributing guidelines](https://ridgeplot.readthedocs.io/en/latest/development/contributing.html).
- [x] Provided the relevant details in the PR's description.
- [x] Referenced relevant issues in the PR's description.
- [ ] Added tests for all my changes. (N/A - CI config only; validated by the CI runs on this PR)
- [ ] Updated the docs for relevant changes. (N/A)
- [x] Changes are documented in `docs/reference/changelog.md`.
- [x] The CI check are all passing, or I'm working on fixing them!
- [x] I have reviewed my own code! 🤠

<!-- readthedocs-preview ridgeplot start -->
----
📚 Documentation preview 📚: https://ridgeplot--386.org.readthedocs.build/en/386/

<!-- readthedocs-preview ridgeplot end -->