### PR TITLE
Adopt pytest's strict mode

### DIFF
--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,7 @@ Unreleased changes
 
 ### CI/CD
 
+- Adopt pytest's strict mode, following the recommendations from pytest's "Good Integration Practices" guide ({gh-pr}`387`)
 - Bump actions/download-artifact from 7 to 8 ({gh-pr}`368`)
 - Bump actions/upload-artifact from 6 to 7 ({gh-pr}`369`)
 - Bump sigstore/gh-action-sigstore-python from 3.2.0 to 3.3.0 ({gh-pr}`370`)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,19 +1,17 @@
 [pytest]
 addopts =
     # Tests summary report
-    # ref: https://docs.pytest.org/en/8.3.x/how-to/output.html#producing-a-detailed-summary-report
+    # ref: https://docs.pytest.org/en/stable/how-to/output.html#producing-a-detailed-summary-report
     -ra
     # (V)Verbose
     -vv
     # Show local variables in tracebacks
     --showlocals
-    # Raise error on unknown markers
-    --strict-markers
     # Import mode
-    # ref: https://docs.pytest.org/en/8.3.x/explanation/pythonpath.html#import-modes
+    # ref: https://docs.pytest.org/en/stable/explanation/pythonpath.html#import-modes
     --import-mode=importlib
     # Minimal duration in seconds for inclusion in slowest list
-    # ref: https://docs.pytest.org/en/8.3.x/how-to/usage.html#profiling-test-execution-duration
+    # ref: https://docs.pytest.org/en/stable/how-to/usage.html#profiling-test-execution-duration
     --durations-min=0.5
     # Fail if a test tries to open a network connection
     # ref: https://github.com/miketheman/pytest-socket
@@ -25,22 +23,25 @@ addopts =
     --no-cov-on-fail
     --cov-report=term-missing
 
+# Enable all of pytest's strictness options (requires pytest>=9).
+# As of pytest 9.1, this enables: strict_config, strict_markers,
+# strict_parametrization_ids, and strict_xfail. Any new strictness
+# options added in future pytest releases will also be picked up here.
+# ref: https://docs.pytest.org/en/stable/explanation/goodpractices.html#using-pytest-s-strict-mode
+# ref: https://docs.pytest.org/en/stable/reference/reference.html#confval-strict
+strict = true
+
 # Default list of directories that pytest will search for tests in.
 # This should be overridden in tox.ini to run specific test suites.
-# https://docs.pytest.org/en/8.3.x/reference/reference.html#confval-testpaths
+# https://docs.pytest.org/en/stable/reference/reference.html#confval-testpaths
 testpaths = tests
 
 # List of directories that should be added to the python search path
-# https://docs.pytest.org/en/8.3.x/reference/reference.html#confval-pythonpath
+# https://docs.pytest.org/en/stable/reference/reference.html#confval-pythonpath
 pythonpath = cicd_utils
 
-# Tests marked with @pytest.mark.xfail that actually
-# succeed will by default fail the test suite.
-# https://docs.pytest.org/en/8.3.x/reference/reference.html#confval-xfail_strict
-xfail_strict = true
-
 # Warning filters pattern: action:message:category:module:line
-# ref: https://docs.pytest.org/en/8.3.x/how-to/capture-warnings.html
+# ref: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
 # ref: https://docs.python.org/3/library/warnings.html#describing-warning-filters
 # ref: https://docs.python.org/3/using/cmdline.html#cmdoption-W
 filterwarnings =

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,6 @@
 # pytest and plugins
-pytest
+# (pytest>=9 is needed for the `strict` config option set in pytest.ini)
+pytest>=9
 pytest-icdiff
 pytest-socket
 

--- a/tests/unit/test_hist.py
+++ b/tests/unit/test_hist.py
@@ -39,7 +39,11 @@ def test_bin_trace_samples_nbins(nbins: int) -> None:
     assert len(density_trace) == nbins
 
 
-@pytest.mark.parametrize("non_finite_value", [np.inf, np.nan, float("inf"), float("nan")])
+@pytest.mark.parametrize(
+    "non_finite_value",
+    [np.inf, np.nan, float("inf"), float("nan")],
+    ids=["np-inf", "np-nan", "float-inf", "float-nan"],
+)
 def test_bin_trace_samples_fails_for_non_finite_values(non_finite_value: float) -> None:
     err_msg = "The samples array should not contain any infs or NaNs."
     with pytest.raises(ValueError, match=err_msg):
@@ -64,7 +68,11 @@ def test_bin_trace_samples_weights_not_same_length() -> None:
         bin_trace_samples(trace_samples=SAMPLES_IN, nbins=NBINS, weights=[1, 1, 1])
 
 
-@pytest.mark.parametrize("non_finite_value", [np.inf, np.nan, float("inf"), float("nan")])
+@pytest.mark.parametrize(
+    "non_finite_value",
+    [np.inf, np.nan, float("inf"), float("nan")],
+    ids=["np-inf", "np-nan", "float-inf", "float-nan"],
+)
 def test_bin_trace_samples_weights_fails_for_non_finite_values(
     non_finite_value: float,
 ) -> None:

--- a/tests/unit/test_kde.py
+++ b/tests/unit/test_kde.py
@@ -49,7 +49,11 @@ def test_estimate_density_trace_points() -> None:
     assert np.argmin(y) == 0
 
 
-@pytest.mark.parametrize("non_finite_value", [np.inf, np.nan, float("inf"), float("nan")])
+@pytest.mark.parametrize(
+    "non_finite_value",
+    [np.inf, np.nan, float("inf"), float("nan")],
+    ids=["np-inf", "np-nan", "float-inf", "float-nan"],
+)
 def test_estimate_density_trace_fails_for_non_finite_values(non_finite_value: float) -> None:
     err_msg = "The samples array should not contain any infs or NaNs."
     with pytest.raises(ValueError, match=err_msg):
@@ -101,7 +105,11 @@ def test_estimate_density_trace_weights_not_same_length() -> None:
         )
 
 
-@pytest.mark.parametrize("non_finite_value", [np.inf, np.nan, float("inf"), float("nan")])
+@pytest.mark.parametrize(
+    "non_finite_value",
+    [np.inf, np.nan, float("inf"), float("nan")],
+    ids=["np-inf", "np-nan", "float-inf", "float-nan"],
+)
 def test_estimate_density_trace_weights_fails_for_non_finite_values(
     non_finite_value: float,
 ) -> None:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -44,7 +44,7 @@ class TestGetXYExtrema:
 
     @pytest.mark.parametrize(
         ("densities_type", "rows_type"),
-        product((id_func, tuple, list), (id_func, tuple, list, np.asarray)),
+        list(product((id_func, tuple, list), (id_func, tuple, list, np.asarray))),
     )
     def test_expected_output(
         self,


### PR DESCRIPTION
Closes #240

## Summary

Went through pytest's [Good Integration Practices](https://docs.pytest.org/en/stable/explanation/goodpractices.html) guide and audited the project against it. Most recommendations were already in place:

- ✅ `src` layout with tests outside application code
- ✅ `--import-mode=importlib` (so the [test package name](https://docs.pytest.org/en/stable/explanation/goodpractices.html#test-package-name) / duplicate-basename concerns don't apply — e.g. the two `test_init.py` modules collect fine without `__init__.py` files)
- ✅ tox testing against the built wheel
- ✅ `flake8-pytest-style` checks (via ruff's `select = ["ALL"]`)

The one remaining gap was [pytest's strict mode](https://docs.pytest.org/en/stable/explanation/goodpractices.html#using-pytest-s-strict-mode), added in pytest 9.0. This PR:

- Enables `strict = true` in `pytest.ini`, superseding the previous `--strict-markers` flag and `xfail_strict` ini option. This also enables `strict_config` and `strict_parametrization_ids`, and will automatically pick up new strictness options as they are added to pytest (consistent with the project's approach of, e.g., ruff's `select = ["ALL"]` and `filterwarnings = error`). If you'd rather not auto-adopt future options, the alternative is to enable the four current `strict_*` options individually.
- Adds a `pytest>=9` floor to `requirements/tests.txt` (pytest 9 supports Python >=3.10, matching this project's minimum).
- Fixes duplicate parametrization IDs surfaced by `strict_parametrization_ids` in `test_hist.py` and `test_kde.py` (`np.inf`/`float("inf")` and `np.nan`/`float("nan")` generate identical IDs) by adding explicit unique `ids=`.
- Fixes `test_utils.py` passing an `itertools.product` iterator to `@pytest.mark.parametrize`, which pytest 9.1 [deprecates for removal in pytest 10](https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators). Note this was already breaking test collection with pytest 9.1.x on `main` (the `PytestRemovedIn10Warning` is promoted to an error by `filterwarnings = error`), independently of this PR.
- Refreshes the pinned `8.3.x` doc links in `pytest.ini` comments to `stable`.

## Test plan

- [x] `pytest tests/unit --doctest-modules src` — 237 passed, 3 xfailed
- [x] `pytest tests/e2e` — 5 passed (1 pre-existing local-only failure: `test_paths_exist` asserts the repo dir is named `ridgeplot`, which doesn't hold in a worktree checkout; passes on CI)
- [x] `pytest tests/cicd_utils` — 24 passed
- [x] `pre-commit` hooks (incl. ruff + ruff-format) pass
- [x] `pyright` — 0 errors

<!-- readthedocs-preview ridgeplot start -->
----
📚 Documentation preview 📚: https://ridgeplot--387.org.readthedocs.build/en/387/

<!-- readthedocs-preview ridgeplot end -->