### PR TITLE
Review coverage config and ratchet package coverage gates to 100%

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,7 +17,7 @@ src =
 [report]
 precision = 1
 show_missing = true
-skip_covered = false
+skip_covered = true
 fail_under = 50
 
 # Some of the patterns below were taken or adapted
@@ -36,6 +36,7 @@ exclude_lines =
     : \.\.\.(\s*#.*)?$
     ^ +\.\.\.$
     -> ['"]?NoReturn['"]?:
+    ^\s*assert_never\b
     # non-runnable code
     if __name__ == ['"]__main__['"]:$
 partial_branches =

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,8 @@ def _coerce_to_densities(...):
 ## CI/CD Pipeline
 
 GitHub Actions runs tests on Python 3.10–3.14 across Ubuntu, macOS, and Windows.
-Codecov minimums are 98% overall and 100% diff coverage for new code.
+Codecov minimums are 100% overall and 100% diff coverage for new code.
+Intentionally-untested lines must carry an explicit `# pragma: no cover` comment.
 
 ## Notes for AI Assistants
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# Codecov configuration
+# ref: https://docs.codecov.com/docs/codecov-yaml
+#
+# Note: CI only uploads the combined coverage report
+# (see the coverage-combine env in tox.ini), which omits
+# "cicd_utils/*" and "tests/*", so these targets apply
+# to the src/ridgeplot package only.
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+    patch:
+      default:
+        target: 100%

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,7 @@ Unreleased changes
 
 ### CI/CD
 
+- Review the coverage configuration in light of `covdefaults`, adopting its `assert_never` exclusion and `skip_covered` report setting, and raising all package coverage gates to 100% ({gh-pr}`390`)
 - Bump actions/download-artifact from 7 to 8 ({gh-pr}`368`)
 - Bump actions/upload-artifact from 6 to 7 ({gh-pr}`369`)
 - Bump sigstore/gh-action-sigstore-python from 3.2.0 to 3.3.0 ({gh-pr}`370`)

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 
     pytest: pytest --no-cov {posargs}
 
-    tests-unit: pytest tests/unit --doctest-modules src {env:_COV_REPORT_XML} --cov-fail-under=95 {posargs:}
+    tests-unit: pytest tests/unit --doctest-modules src {env:_COV_REPORT_XML} --cov-fail-under=100 {posargs:}
     tests-unit: diff-cover {env:_DIFFCOVER_DFLT_ARGS} --fail-under=100
 
     tests-e2e: pytest tests/e2e --cov=cicd_utils/ridgeplot_examples {env:_COV_REPORT_XML} --cov-fail-under=74 {posargs:}
@@ -49,7 +49,7 @@ commands =
     coverage-combine: mv .coverage {env:COVERAGE_FILE}
     coverage-combine: coverage xml  --data-file={env:COVERAGE_FILE} --omit="cicd_utils/*,tests/*" -o {env:COVERAGE_XML_FILE}
     coverage-combine: coverage html --data-file={env:COVERAGE_FILE} --omit="cicd_utils/*,tests/*"
-    coverage-combine: coverage report --data-file={env:COVERAGE_FILE} --omit="cicd_utils/*,tests/*" --fail-under=98
+    coverage-combine: coverage report --data-file={env:COVERAGE_FILE} --omit="cicd_utils/*,tests/*" --fail-under=100
     coverage-combine: diff-cover {env:_DIFFCOVER_DFLT_ARGS} --fail-under=100
 
 [testenv:pre-commit-{all,quick,autoupgrade}]


### PR DESCRIPTION
## Summary

Follow-up review of #155 ("Review usage of `covdefaults` and `.coveragerc`"):

- `covdefaults` itself was already removed in the June 2024 coverage refactor (f39c672) — and notably, the plugin was never actually active (no `plugins = covdefaults` ever existed in `.coveragerc`), which also explains why `sys.version_info` blocks stopped being excluded back then.
- This PR adopts the remaining useful bits from covdefaults and ratchets the coverage gates to the current baseline, which is already at 100%:
  - `.coveragerc`: add `^\s*assert_never\b` to `exclude_lines`; set `skip_covered = true`
  - `tox.ini`: raise `tests-unit` gate 95 → 100 and the combined-report gate 98 → 100
  - `codecov.yml` (new): make the Codecov 100% project/patch targets explicit in-repo (CI only uploads the combined report, which omits `cicd_utils/*` and `tests/*`, so these targets apply to `src/ridgeplot` only)
  - `AGENTS.md`: document the new policy — intentionally-untested lines must carry an explicit `# pragma: no cover`

Not adopted from covdefaults (with rationale): the platform/version pragma machinery (no gated code paths exist; this is the only part that genuinely requires the plugin), the `*/__main__.py`/`*/setup.py` omits (none exist), and the `source = .` fallback (per-suite `--cov` targets are more precise).

Closes #155

## Test plan

- [x] `coverage debug config` parses the new `.coveragerc` correctly
- [x] Unit suite passes the new `--cov-fail-under=100` gate (237 passed, 3 xfailed; 100.0%)
- [x] Full CI flow replicated locally: all three suites + `coverage combine` + `coverage report --fail-under=100` (657 stmts, 0 missed, 170 branches, 0 partial)
- [ ] CI green across the Python 3.10–3.14 matrix

<!-- readthedocs-preview ridgeplot start -->
----
📚 Documentation preview 📚: https://ridgeplot--390.org.readthedocs.build/en/390/

<!-- readthedocs-preview ridgeplot end -->