### PR TITLE
Make e2e path sanity check worktree-friendly

### DIFF
--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,7 @@ Unreleased changes
 
 ### CI/CD
 
+- Make the e2e path sanity check independent of the checkout directory's name, so tests can run from git worktrees ({gh-pr}`391`)
 - Bump actions/download-artifact from 7 to 8 ({gh-pr}`368`)
 - Bump actions/upload-artifact from 6 to 7 ({gh-pr}`369`)
 - Bump sigstore/gh-action-sigstore-python from 3.2.0 to 3.3.0 ({gh-pr}`370`)

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -13,7 +13,10 @@ PATH_CHARTS = PATH_ROOT / "docs/_static/charts"
 
 
 def test_paths_exist() -> None:
-    assert PATH_ROOT.name == "ridgeplot"
+    # Sanity check that PATH_ROOT points at the repo root, without
+    # depending on the name of the checkout directory (which differs
+    # in git worktrees and renamed clones)
+    assert (PATH_ROOT / "pyproject.toml").is_file()
     assert PATH_ARTIFACTS.is_dir()
     assert PATH_CHARTS.is_dir()
 


### PR DESCRIPTION
## Summary

- `tests/e2e/test_examples.py::test_paths_exist` asserted that the repository root directory is named `ridgeplot`. That check always fails when the test suite runs from a git worktree or a clone with a different directory name, even though the computed paths are perfectly valid.
- Replace the directory-name assertion with a repo-root marker check (`pyproject.toml` exists), which validates the same thing — that the `Path(__file__).parents[2]` arithmetic landed on the repo root — without depending on the checkout directory's name.

## Test plan

- [x] `pytest tests/e2e` passes from a git worktree checkout (previously `test_paths_exist` failed there): 6 passed

<!-- readthedocs-preview ridgeplot start -->
----
📚 Documentation preview 📚: https://ridgeplot--391.org.readthedocs.build/en/391/

<!-- readthedocs-preview ridgeplot end -->