### PR TITLE
Manage the CI Python interpreter with uv

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -13,18 +13,20 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "${{ inputs.python-version }}"
-
-    # Install uv and enable its built-in cache. The cache key takes the
-    # platform, the uv version, and a hash of the files below into account.
+    # Install uv together with a uv-managed Python interpreter, and
+    # create and activate a virtual environment that is used by all
+    # subsequent steps (e.g. the `uv pip install` step below installs
+    # into it). Also enables uv's built-in cache. The cache key takes
+    # the platform, the uv version, and a hash of the files below
+    # into account.
     # See https://docs.astral.sh/uv/guides/integration/github/ for details.
     # NOTE: setup-uv publishes immutable releases only (no
     #       floating major tags), so we pin the full version
-    - name: Install uv
+    - name: Install uv and python
       uses: astral-sh/setup-uv@v9.0.0
       with:
+        python-version: "${{ inputs.python-version }}"
+        activate-environment: true
         enable-cache: true
         cache-suffix: "py${{ inputs.python-version }}"
         cache-dependency-glob: |
@@ -34,4 +36,4 @@ runs:
     - name: Install requirements
       if: ${{ inputs.requirements != '' }}
       shell: bash
-      run: uv pip install --verbose --system ${{ inputs.requirements }}
+      run: uv pip install --verbose ${{ inputs.requirements }}

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -31,6 +31,7 @@ Unreleased changes
 - pre-commit autoupdate ({gh-pr}`379`)
 - Fix the test suite's compatibility with the latest pytest release ({gh-pr}`384`)
 - Use the official `astral-sh/setup-uv` action to install and cache `uv` in CI ({gh-pr}`386`)
+- Let `uv` manage the Python interpreter and virtual environment in CI ({gh-pr}`393`)
 
 ---
 


### PR DESCRIPTION
## Description

Let `uv` fully manage the Python interpreter in CI, as part of the `uv` adoption tracked in #219. The `setup-python` composite action now uses `astral-sh/setup-uv`'s `python-version` and `activate-environment` inputs and drops `actions/setup-python` entirely:

- The requested Python version is installed as a uv-managed interpreter ([python-build-standalone](https://github.com/astral-sh/python-build-standalone) builds) instead of GitHub's toolcache CPython.
- setup-uv creates and activates a virtual environment used by all subsequent steps, so the `requirements` install step targets it directly (dropping `--system`). Tox then uses the venv's interpreter as its host Python, so the test matrix versions are honored exactly as before.

Note: this change previously ran on `main` as eed5995 (accidental direct push, since reverted in a70141e so it could be reviewed here). All workflows passed on that commit, including the full 3.10-3.14 test matrix, the release workflow's dist build, and the docs build - so the change is already CI-validated end-to-end.

## Related issues

Related to #219.

## PR check list

- [x] Read the [contributing guidelines](https://ridgeplot.readthedocs.io/en/latest/development/contributing.html).
- [x] Provided the relevant details in the PR's description.
- [x] Referenced relevant issues in the PR's description.
- [ ] Added tests for all my changes. (N/A - CI config only; validated by the CI runs on this PR)
- [ ] Updated the docs for relevant changes. (N/A)
- [x] Changes are documented in `docs/reference/changelog.md`.
- [x] The CI check are all passing, or I'm working on fixing them!
- [x] I have reviewed my own code! 🤠

<!-- readthedocs-preview ridgeplot start -->
----
📚 Documentation preview 📚: https://ridgeplot--393.org.readthedocs.build/en/393/

<!-- readthedocs-preview ridgeplot end -->