### PR TITLE
Remove the stale requirements/*.txt glob from the CI cache key

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: "Python version (e.g. '3.7', '3.8.13', '3.11.0-alpha.1', '3.x')."
     required: true
   requirements:
-    description: "Optional list of arguments passed to `uv pip install` (e.g. 'numpy==1.19.5', '-r requirements.txt')."
+    description: "Optional list of arguments passed to `uv pip install` (e.g. 'tox', 'numpy==1.19.5')."
     required: false
 
 runs:
@@ -17,7 +17,7 @@ runs:
     # create and activate a virtual environment that is used by all
     # subsequent steps (e.g. the `uv pip install` step below installs
     # into it). Also enables uv's built-in cache. The cache key takes
-    # the platform, the uv version, and a hash of the files below
+    # the platform, the uv version, and a hash of pyproject.toml
     # into account.
     # See https://docs.astral.sh/uv/guides/integration/github/ for details.
     # NOTE: setup-uv publishes immutable releases only (no
@@ -29,9 +29,7 @@ runs:
         activate-environment: true
         enable-cache: true
         cache-suffix: "py${{ inputs.python-version }}"
-        cache-dependency-glob: |
-          pyproject.toml
-          requirements/*.txt
+        cache-dependency-glob: pyproject.toml
 
     - name: Install requirements
       if: ${{ inputs.requirements != '' }}

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -36,6 +36,7 @@ Unreleased changes
 - Fix the test suite's compatibility with the latest pytest release ({gh-pr}`384`)
 - Use the official `astral-sh/setup-uv` action to install and cache `uv` in CI ({gh-pr}`386`)
 - Let `uv` manage the Python interpreter and virtual environment in CI ({gh-pr}`393`)
+- Remove the stale `requirements/*.txt` glob from the CI cache key, left over from the migration to PEP 735 dependency groups ({gh-pr}`394`)
 
 ---
 


### PR DESCRIPTION
## Description

Small cleanup left over from #388: the `requirements/` directory no longer exists (all development dependencies now live in PEP 735 dependency groups in `pyproject.toml`), but the `setup-python` composite action still listed `requirements/*.txt` in setup-uv's `cache-dependency-glob`. This removes the dead glob so the cache key is derived from `pyproject.toml` alone, and updates the (stale) `-r requirements.txt` example in the `requirements` input description.

No behaviour change expected: the glob matched nothing, so cache keys stay the same.

## Related issues

Related to #219 (follow-up to #388).

## PR check list

- [x] Read the [contributing guidelines](https://ridgeplot.readthedocs.io/en/latest/development/contributing.html).
- [x] Provided the relevant details in the PR's description.
- [x] Referenced relevant issues in the PR's description.
- [ ] Added tests for all my changes. (N/A - CI config only)
- [ ] Updated the docs for relevant changes. (N/A)
- [x] Changes are documented in `docs/reference/changelog.md`.
- [x] The CI check are all passing, or I'm working on fixing them!
- [x] I have reviewed my own code! 🤠

<!-- readthedocs-preview ridgeplot start -->
----
📚 Documentation preview 📚: https://ridgeplot--394.org.readthedocs.build/en/394/

<!-- readthedocs-preview ridgeplot end -->