### PR TITLE
Use pre-commit-uv to speed up pre-commit hook environment installs

### DIFF
--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -16,6 +16,7 @@ Unreleased changes
 ### Developer Experience
 
 - Migrate all development dependencies from `requirements/*.txt` files to PEP 735 dependency groups in `pyproject.toml` ({gh-pr}`388`)
+- Use `pre-commit-uv` to speed up pre-commit hook environment installs ({gh-pr}`396`)
 
 ### CI/CD
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,8 +134,10 @@ local-dev = [
     "setuptools-scm>=8",
     # Tox
     "tox",
-    # pre-commit
+    # pre-commit (the pre-commit-uv plugin makes pre-commit
+    # build its hook environments with uv - faster installs)
     "pre-commit",
+    "pre-commit-uv",
     # Releases are still a manual process that
     # requires the use of bumpversion locally
     "bumpversion",

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,11 @@ passenv =
     XDG_CACHE_HOME
     SSH_AUTH_SOCK
 skip_install = true
-deps = pre-commit
+deps =
+    pre-commit
+    # Plugin that makes pre-commit build its hook
+    # environments with uv (faster installs)
+    pre-commit-uv
 commands =
     all:   pre-commit run --all-files --show-diff-on-failure {posargs:}
     quick: pre-commit run ruff-format --all-files


### PR DESCRIPTION
## Description

Another small step for the `uv` adoption tracked in #219 - this time on the pre-commit front.

Adds [`pre-commit-uv`](https://github.com/tox-dev/pre-commit-uv) alongside `pre-commit` (in the `pre-commit-*` tox envs and in the `local-dev` dependency group), so that pre-commit builds its hook environments with `uv` instead of `virtualenv`+`pip`. No configuration changes are needed - the plugin activates automatically when installed next to `pre-commit`:

```text
[INFO] Using pre-commit with uv 0.11.32 via pre-commit-uv 4.3.0
```

Locally validated: `tox -e pre-commit-quick --recreate` and `tox -e pre-commit-all` both pass, with all hook environments (cold install) built via uv in ~22s total.

Note on the remaining "pre-commit integration" checklist item in #219: the [official uv pre-commit guide](https://docs.astral.sh/uv/guides/integration/pre-commit/) only covers the `uv-pre-commit` hooks (`uv-lock`, `uv-export`, `pip-compile`), all of which require a committed `uv.lock` or requirements files - neither of which this repo has (by design, after #388). So that item is blocked on the (separate) decision of whether to adopt a committed `uv.lock`. This PR covers what can be done on the pre-commit front today.

## Related issues

Related to #219.

## PR check list

- [x] Read the [contributing guidelines](https://ridgeplot.readthedocs.io/en/latest/development/contributing.html).
- [x] Provided the relevant details in the PR's description.
- [x] Referenced relevant issues in the PR's description.
- [ ] Added tests for all my changes. (N/A - dev tooling only)
- [ ] Updated the docs for relevant changes. (N/A)
- [x] Changes are documented in `docs/reference/changelog.md`.
- [x] The CI check are all passing, or I'm working on fixing them!
- [x] I have reviewed my own code! 🤠

<!-- readthedocs-preview ridgeplot start -->
----
📚 Documentation preview 📚: https://ridgeplot--396.org.readthedocs.build/en/396/

<!-- readthedocs-preview ridgeplot end -->