### PR TITLE
Replace broken `actions/first-interaction` with an inline github-script

### DIFF
--- a/.github/actions/greet-new-users/action.yml
+++ b/.github/actions/greet-new-users/action.yml
@@ -1,0 +1,44 @@
+name: Greet new users
+
+description: >-
+  Comment on a user's first issue or pull request. A drop-in replacement for
+  actions/first-interaction, whose v3 rewrite greets every PR from any author
+  who never opened an issue in the repository - including every PR from bots
+  like pre-commit.ci and dependabot. See
+  https://github.com/actions/first-interaction/issues/369 for details.
+
+inputs:
+  issue-message:
+    description: "Message to post on a user's first issue. Leave empty to not greet issues."
+    required: false
+  pr-message:
+    description: "Message to post on a user's first pull request. Leave empty to not greet PRs."
+    required: false
+  token:
+    description: >-
+      GitHub token used to list existing issues/PRs and to post the greeting
+      comment. Requires `issues: write` and `pull-requests: write` permissions.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  greeted:
+    description: "Whether a greeting comment was posted ('true'/'false')."
+    value: ${{ steps.greet.outputs.greeted }}
+
+runs:
+  using: composite
+  steps:
+    - id: greet
+      uses: actions/github-script@v9
+      env:
+        ISSUE_MESSAGE: ${{ inputs.issue-message }}
+        PR_MESSAGE: ${{ inputs.pr-message }}
+      with:
+        github-token: ${{ inputs.token }}
+        # The logic lives in main.js next to this file. The messages are
+        # passed through the environment so that no user-controlled content
+        # is ever `${{ }}`-interpolated into the script source.
+        script: |
+          const greet = require(`${process.env.GITHUB_ACTION_PATH}/main.js`)
+          await greet({ core, context, github })

--- a/.github/actions/greet-new-users/action.yml
+++ b/.github/actions/greet-new-users/action.yml
@@ -8,10 +8,10 @@ description: >-
   https://github.com/actions/first-interaction/issues/369 for details.
 
 inputs:
-  issue-message:
+  issue_message:
     description: "Message to post on a user's first issue. Leave empty to not greet issues."
     required: false
-  pr-message:
+  pr_message:
     description: "Message to post on a user's first pull request. Leave empty to not greet PRs."
     required: false
   token:
@@ -32,8 +32,8 @@ runs:
     - id: greet
       uses: actions/github-script@v9
       env:
-        ISSUE_MESSAGE: ${{ inputs.issue-message }}
-        PR_MESSAGE: ${{ inputs.pr-message }}
+        ISSUE_MESSAGE: ${{ inputs.issue_message }}
+        PR_MESSAGE: ${{ inputs.pr_message }}
       with:
         github-token: ${{ inputs.token }}
         # The logic lives in main.js next to this file. The messages are

--- a/.github/actions/greet-new-users/main.js
+++ b/.github/actions/greet-new-users/main.js
@@ -1,0 +1,90 @@
+// Core logic for the greet-new-users composite action (see action.yml).
+//
+// Kept in a standalone CommonJS module - rather than inline in action.yml -
+// so it can be linted, syntax-checked, and unit-tested directly. It is
+// invoked from actions/github-script, which injects its pre-authenticated
+// Octokit client (`github`) plus the `core` and `context` helpers.
+//
+// The greeting messages are read from the ISSUE_MESSAGE / PR_MESSAGE
+// environment variables (so that no user-controlled content is ever
+// `${{ }}`-interpolated into script source), and a `greeted` output
+// ("true"/"false") is always set.
+
+module.exports = async function greet({ core, context, github }) {
+  core.setOutput('greeted', 'false')
+  try {
+    // Only greet on newly created issues/PRs. Guards against consumers
+    // triggering this action on e.g. `edited` events, which would
+    // otherwise post duplicate greetings.
+    if (context.payload.action !== 'opened') {
+      return core.info(`Skipping: unsupported event action (${context.payload.action})`)
+    }
+
+    const isIssue = context.eventName === 'issues'
+    const item = isIssue ? context.payload.issue : context.payload.pull_request
+    if (!item) {
+      return core.info(`Skipping: unsupported event (${context.eventName})`)
+    }
+
+    const message = isIssue ? process.env.ISSUE_MESSAGE : process.env.PR_MESSAGE
+    if (!message) {
+      return core.info(`Skipping: no ${isIssue ? 'issue' : 'pull request'} message configured`)
+    }
+
+    // Never greet bots (pre-commit.ci, dependabot, github-actions, Copilot, ...)
+    const author = item.user
+    if (author.type === 'Bot') {
+      return core.info(`Skipping: ${author.login} is a bot`)
+    }
+
+    // Repo-affiliated authors are never "new users". This is only a
+    // shortcut: a missing/unreliable value falls through to the real
+    // check below, so it can never cause a wrong greeting.
+    if (['OWNER', 'MEMBER', 'COLLABORATOR'].includes(item.author_association)) {
+      return core.info(`Skipping: ${author.login} is ${item.author_association}`)
+    }
+
+    let isFirst = true
+    if (isIssue) {
+      // Everything this author created (the endpoint returns PRs too,
+      // so keep only true issues that predate the current one).
+      const created = await github.paginate(github.rest.issues.listForRepo, {
+        ...context.repo,
+        creator: author.login,
+        state: 'all',
+        per_page: 100,
+      })
+      isFirst = !created.some((i) => !i.pull_request && i.number < item.number)
+    } else {
+      // pulls.list cannot filter by author, so scan all PRs and stop
+      // as soon as an older PR by this author shows up.
+      await github.paginate(
+        github.rest.pulls.list,
+        { ...context.repo, state: 'all', per_page: 100 },
+        (response, done) => {
+          if (response.data.some((p) => p.user?.login === author.login && p.number < item.number)) {
+            isFirst = false
+            done()
+          }
+          return []
+        },
+      )
+    }
+
+    if (!isFirst) {
+      return core.info(`Skipping: not ${author.login}'s first ${isIssue ? 'issue' : 'pull request'}`)
+    }
+
+    core.info(`Greeting ${author.login} on their first ${isIssue ? 'issue' : 'pull request'}`)
+    await github.rest.issues.createComment({
+      ...context.repo,
+      issue_number: item.number,
+      body: message,
+    })
+    core.setOutput('greeted', 'true')
+  } catch (error) {
+    // The greeting is cosmetic: a red X on a newcomer's first PR is
+    // worse than a missing welcome, so warn instead of failing.
+    core.warning(`Skipping greeting: ${error.message}`)
+  }
+}

--- a/.github/workflows/greet-new-users.yml
+++ b/.github/workflows/greet-new-users.yml
@@ -31,13 +31,13 @@ jobs:
 
       - uses: ./.github/actions/greet-new-users
         with:
-          issue-message: |
+          issue_message: |
             **Thank you for submitting your first issue with us!** 🎉
 
             Our response times may vary, but we'll get back to you as soon as we can!
 
             Welcome aboard! 🚀
-          pr-message: |
+          pr_message: |
             **Thank you for submitting your first pull request with us!** 🎉
 
             Our response times may vary, but we'll get back to you as soon as we can!

--- a/.github/workflows/greet-new-users.yml
+++ b/.github/workflows/greet-new-users.yml
@@ -7,11 +7,13 @@ on:
     types: [ opened ]
 
 # SECURITY: pull_request_target runs with a write token in the base-repo
-# context. This workflow must never check out or execute anything from the
-# PR head, and untrusted fields (titles, bodies, logins) must never be
-# `${{ }}`-interpolated into the script source — read them via
-# `context.payload` inside the script instead.
+# context. Only the *base* ref may ever be checked out here (the checkout
+# below uses the default ref, which on pull_request_target is the base
+# branch) - never the PR head. Untrusted fields (titles, bodies, logins)
+# must never be `${{ }}`-interpolated into scripts; the greet-new-users
+# action reads them via `context.payload` instead.
 permissions:
+  contents: read
   issues: write
   pull-requests: write
 
@@ -20,19 +22,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      # Inline replacement for actions/first-interaction, which greets every
-      # PR from any author who never opened an issue in this repo (including
-      # bots like pre-commit.ci and dependabot).
-      # See: https://github.com/actions/first-interaction/issues/369
-      - uses: actions/github-script@v9
-        env:
-          ISSUE_MESSAGE: |
+      # Needed to load the local action. On pull_request_target this checks
+      # out the base branch, so PR authors cannot alter the code that runs
+      # in this privileged workflow.
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/greet-new-users
+        with:
+          issue-message: |
             **Thank you for submitting your first issue with us!** 🎉
 
             Our response times may vary, but we'll get back to you as soon as we can!
 
             Welcome aboard! 🚀
-          PR_MESSAGE: |
+          pr-message: |
             **Thank you for submitting your first pull request with us!** 🎉
 
             Our response times may vary, but we'll get back to you as soon as we can!
@@ -40,64 +45,3 @@ jobs:
             To help us help you, please make sure you have ticked all the boxes in the pull request template.
 
             Welcome aboard! 🚀
-        with:
-          script: |
-            try {
-              const isIssue = context.eventName === 'issues'
-              const item = isIssue ? context.payload.issue : context.payload.pull_request
-              const author = item.user
-
-              // Never greet bots (pre-commit.ci, dependabot, github-actions, Copilot, ...)
-              if (author.type === 'Bot') {
-                return core.info(`Skipping: ${author.login} is a bot`)
-              }
-
-              // Repo-affiliated authors are never "new users". This is only a
-              // shortcut: a missing/unreliable value falls through to the real
-              // check below, so it can never cause a wrong greeting.
-              if (['OWNER', 'MEMBER', 'COLLABORATOR'].includes(item.author_association)) {
-                return core.info(`Skipping: ${author.login} is ${item.author_association}`)
-              }
-
-              let isFirst = true
-              if (isIssue) {
-                // Everything this author created (the endpoint returns PRs too,
-                // so keep only true issues that predate the current one).
-                const created = await github.paginate(github.rest.issues.listForRepo, {
-                  ...context.repo,
-                  creator: author.login,
-                  state: 'all',
-                  per_page: 100,
-                })
-                isFirst = !created.some((i) => !i.pull_request && i.number < item.number)
-              } else {
-                // pulls.list cannot filter by author, so scan all PRs and stop
-                // as soon as an older PR by this author shows up.
-                await github.paginate(
-                  github.rest.pulls.list,
-                  { ...context.repo, state: 'all', per_page: 100 },
-                  (response, done) => {
-                    if (response.data.some((p) => p.user?.login === author.login && p.number < item.number)) {
-                      isFirst = false
-                      done()
-                    }
-                    return []
-                  },
-                )
-              }
-
-              if (!isFirst) {
-                return core.info(`Skipping: not ${author.login}'s first ${isIssue ? 'issue' : 'pull request'}`)
-              }
-
-              core.info(`Greeting ${author.login} on their first ${isIssue ? 'issue' : 'pull request'}`)
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: item.number,
-                body: isIssue ? process.env.ISSUE_MESSAGE : process.env.PR_MESSAGE,
-              })
-            } catch (error) {
-              // The greeting is cosmetic: a red X on a newcomer's first PR is
-              // worse than a missing welcome, so warn instead of failing.
-              core.warning(`Skipping greeting: ${error.message}`)
-            }

--- a/.github/workflows/greet-new-users.yml
+++ b/.github/workflows/greet-new-users.yml
@@ -6,21 +6,33 @@ on:
   pull_request_target:
     types: [ opened ]
 
+# SECURITY: pull_request_target runs with a write token in the base-repo
+# context. This workflow must never check out or execute anything from the
+# PR head, and untrusted fields (titles, bodies, logins) must never be
+# `${{ }}`-interpolated into the script source — read them via
+# `context.payload` inside the script instead.
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   greeting:
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     steps:
-      - uses: actions/first-interaction@v3
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          issue_message: |
+      # Inline replacement for actions/first-interaction, which greets every
+      # PR from any author who never opened an issue in this repo (including
+      # bots like pre-commit.ci and dependabot).
+      # See: https://github.com/actions/first-interaction/issues/369
+      - uses: actions/github-script@v9
+        env:
+          ISSUE_MESSAGE: |
             **Thank you for submitting your first issue with us!** 🎉
 
             Our response times may vary, but we'll get back to you as soon as we can!
 
             Welcome aboard! 🚀
-          pr_message: |
+          PR_MESSAGE: |
             **Thank you for submitting your first pull request with us!** 🎉
 
             Our response times may vary, but we'll get back to you as soon as we can!
@@ -28,3 +40,64 @@ jobs:
             To help us help you, please make sure you have ticked all the boxes in the pull request template.
 
             Welcome aboard! 🚀
+        with:
+          script: |
+            try {
+              const isIssue = context.eventName === 'issues'
+              const item = isIssue ? context.payload.issue : context.payload.pull_request
+              const author = item.user
+
+              // Never greet bots (pre-commit.ci, dependabot, github-actions, Copilot, ...)
+              if (author.type === 'Bot') {
+                return core.info(`Skipping: ${author.login} is a bot`)
+              }
+
+              // Repo-affiliated authors are never "new users". This is only a
+              // shortcut: a missing/unreliable value falls through to the real
+              // check below, so it can never cause a wrong greeting.
+              if (['OWNER', 'MEMBER', 'COLLABORATOR'].includes(item.author_association)) {
+                return core.info(`Skipping: ${author.login} is ${item.author_association}`)
+              }
+
+              let isFirst = true
+              if (isIssue) {
+                // Everything this author created (the endpoint returns PRs too,
+                // so keep only true issues that predate the current one).
+                const created = await github.paginate(github.rest.issues.listForRepo, {
+                  ...context.repo,
+                  creator: author.login,
+                  state: 'all',
+                  per_page: 100,
+                })
+                isFirst = !created.some((i) => !i.pull_request && i.number < item.number)
+              } else {
+                // pulls.list cannot filter by author, so scan all PRs and stop
+                // as soon as an older PR by this author shows up.
+                await github.paginate(
+                  github.rest.pulls.list,
+                  { ...context.repo, state: 'all', per_page: 100 },
+                  (response, done) => {
+                    if (response.data.some((p) => p.user?.login === author.login && p.number < item.number)) {
+                      isFirst = false
+                      done()
+                    }
+                    return []
+                  },
+                )
+              }
+
+              if (!isFirst) {
+                return core.info(`Skipping: not ${author.login}'s first ${isIssue ? 'issue' : 'pull request'}`)
+              }
+
+              core.info(`Greeting ${author.login} on their first ${isIssue ? 'issue' : 'pull request'}`)
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: item.number,
+                body: isIssue ? process.env.ISSUE_MESSAGE : process.env.PR_MESSAGE,
+              })
+            } catch (error) {
+              // The greeting is cosmetic: a red X on a newcomer's first PR is
+              // worse than a missing welcome, so warn instead of failing.
+              core.warning(`Skipping greeting: ${error.message}`)
+            }

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -37,7 +37,7 @@ Unreleased changes
 - Use the official `astral-sh/setup-uv` action to install and cache `uv` in CI ({gh-pr}`386`)
 - Let `uv` manage the Python interpreter and virtual environment in CI ({gh-pr}`393`)
 - Remove the stale `requirements/*.txt` glob from the CI cache key, left over from the migration to PEP 735 dependency groups ({gh-pr}`394`)
-- Replace the broken `actions/first-interaction` action with an inline `actions/github-script` step, so that first-time greetings are no longer posted on every PR opened by bots like pre-commit.ci and dependabot ({gh-pr}`398`)
+- Replace the broken `actions/first-interaction` action with a local reusable action (`.github/actions/greet-new-users`), so that first-time greetings are no longer posted on every PR opened by bots like pre-commit.ci and dependabot ({gh-pr}`398`)
 
 ---
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -37,6 +37,7 @@ Unreleased changes
 - Use the official `astral-sh/setup-uv` action to install and cache `uv` in CI ({gh-pr}`386`)
 - Let `uv` manage the Python interpreter and virtual environment in CI ({gh-pr}`393`)
 - Remove the stale `requirements/*.txt` glob from the CI cache key, left over from the migration to PEP 735 dependency groups ({gh-pr}`394`)
+- Replace the broken `actions/first-interaction` action with an inline `actions/github-script` step, so that first-time greetings are no longer posted on every PR opened by bots like pre-commit.ci and dependabot ({gh-pr}`398`)
 
 ---
 


### PR DESCRIPTION
## Description

`actions/first-interaction@v3` posts the "first pull request" greeting on every PR from any author who has never opened an **issue** in this repo — which in practice means every PR from pre-commit.ci, dependabot, and Copilot (#350, #355, #358, #362, #366, #374, #379, #380–#383, #395, ...). The v3 rewrite introduced two regressions: it ORs the first-issue/first-PR checks together instead of branching on the event type, and its first-PR check lost the per-author filter entirely. The bug also affects humans: any contributor who never filed an issue here would be re-greeted on every new PR. Upstream has been broken since Oct 2025 with no fix in sight.

This PR replaces the action with a local reusable composite action, `.github/actions/greet-new-users`, built on `actions/github-script@v9` (already a dependency of other workflows here) with the core logic in a standalone, directly-testable `main.js` module. It restores the correct v1 semantics and hardens the workflow:

- Never greet bots (`user.type == "Bot"`: pre-commit.ci, dependabot, github-actions, Copilot, ...)
- Skip `OWNER`/`MEMBER`/`COLLABORATOR` authors cheaply (shortcut only — a missing/unreliable `author_association` falls through to the real check, so it can never cause a wrong greeting)
- Real detection matches v1: first issue = no earlier issues by the same creator; first PR = no earlier PRs by the same author (early-exit pagination)
- Keys off the resource **author** rather than the event sender (deterministic for agent-created PRs)
- Explicit least-privilege `permissions:` block (`contents: read` + `issues: write` + `pull-requests: write`) instead of the repo-default write-all token
- Fail-soft: API errors log a warning instead of putting a red ❌ on a newcomer's first PR
- Security invariants documented in-file: the `pull_request_target` workflow only ever checks out the **base** ref (required to load the local action; PR authors cannot alter the code this privileged workflow runs), and no untrusted fields are `${{ }}`-interpolated into script source (messages flow through `env`, payload fields are read via `context.payload`)

The action is reusable by design — `issue_message`/`pr_message`/`token` inputs, a `greeted` output, only acts on `opened` events (no duplicate greetings if a consumer also triggers on `edited`), and skips unsupported events gracefully — so other repos can consume it via `uses: tpvasconcelos/ridgeplot/.github/actions/greet-new-users@main`, and open-sourcing it later is just a matter of moving the directory to a standalone repository.

Validation performed:

- All pre-commit hooks pass (incl. `check-yaml`, GitHub Actions/workflow schema validation, `actionlint`, and the `timeout-minutes` hook)
- `main.js` was behavior-tested under Node against mocked `core`/`context`/`github` objects replaying real scenarios: pre-commit-ci's #395, owner PRs, a repeat external contributor, a genuine first PR/issue, a second issue from the same reporter, a first issue from a previous PR author, an API failure, an `edited` event, an unsupported event, and an empty message — 11/11 pass
- Decision logic cross-checked against live API data for every author category this repo has seen

Note: `issues` and `pull_request_target` workflows run the **default-branch** version, so this only takes effect after merging. The next pre-commit.ci autoupdate is the natural negative test; the next external contributor is the positive one.

## Related issues

Upstream: [actions/first-interaction#369](https://github.com/actions/first-interaction/issues/369) (broken first-contribution detection), [actions/first-interaction#394](https://github.com/actions/first-interaction/issues/394) (request to ignore bots). Latest upstream release is still v3.1.0 (Oct 2025); both issues remain open.

## PR check list

- [x] Read the [contributing guidelines](https://ridgeplot.readthedocs.io/en/latest/development/contributing.html).
- [x] Provided the relevant details in the PR's description.
- [x] Referenced relevant issues in the PR's description.
- [x] Added tests for all my changes. (No Python code changed; `main.js` was behavior-tested under Node with mocked payloads — see description.)
- [x] Updated the docs for relevant changes. (N/A — workflow/action-only change; no modules or public API touched.)
- [x] Changes are documented in `docs/reference/changelog.md`.
- [x] Consider granting push permissions to your PR's branch. (Branch lives in this repo.)
- [x] The CI check are all passing, or I'm working on fixing them!
- [x] I have reviewed my own code! 🤠

<!-- readthedocs-preview ridgeplot start -->
----
📚 Documentation preview 📚: https://ridgeplot--398.org.readthedocs.build/en/398/

<!-- readthedocs-preview ridgeplot end -->
